### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 PyYAML>=3.11
 prettytable>=0.7.2
 paramiko>=1.15.2
-ansible>=1.9.1
+ansible>=1.9.1,<2.0
 python-novaclient>=2.24.1
 python-neutronclient>=2.5.0
 python-glanceclient>=0.18.0


### PR DESCRIPTION
Specifying ansible version to be greater than equal to leads to installation of latest 2.\* version. Imports in utils/ansibleutils.py fail due to this. We can also fix this to 1.9.4 if needed.
