### PR TITLE
CA cert check in credentials.py

### DIFF
--- a/monitors/plugins/openstack_api/credentials.py
+++ b/monitors/plugins/openstack_api/credentials.py
@@ -28,7 +28,7 @@ class Credentials(object):
         dct['password'] = self.rc_password
         dct['auth_url'] = self.rc_auth_url
         dct['tenant_name'] = self.rc_tenant_name
-	dct['cacert'] = self.rc_cacert
+        dct['cacert'] = self.rc_cacert
         return dct
 
     def get_nova_credentials(self):
@@ -37,7 +37,7 @@ class Credentials(object):
         dct['api_key'] = self.rc_password
         dct['auth_url'] = self.rc_auth_url
         dct['project_id'] = self.rc_tenant_name
-	dct['cacert'] = self.rc_cacert
+        dct['cacert'] = self.rc_cacert
         return dct
 
     def get_nova_credentials_v2(self):

--- a/monitors/plugins/openstack_api/credentials.py
+++ b/monitors/plugins/openstack_api/credentials.py
@@ -28,6 +28,7 @@ class Credentials(object):
         dct['password'] = self.rc_password
         dct['auth_url'] = self.rc_auth_url
         dct['tenant_name'] = self.rc_tenant_name
+	dct['cacert'] = self.rc_cacert
         return dct
 
     def get_nova_credentials(self):
@@ -36,6 +37,7 @@ class Credentials(object):
         dct['api_key'] = self.rc_password
         dct['auth_url'] = self.rc_auth_url
         dct['project_id'] = self.rc_tenant_name
+	dct['cacert'] = self.rc_cacert
         return dct
 
     def get_nova_credentials_v2(self):
@@ -52,6 +54,7 @@ class Credentials(object):
         self.rc_username = None
         self.rc_tenant_name = None
         self.rc_auth_url = None
+        self.rc_cacert = None
         success = True
 
         if openrc_file:
@@ -80,6 +83,8 @@ class Credentials(object):
                             self.rc_auth_url = value
                         elif name == 'TENANT_NAME':
                             self.rc_tenant_name = value
+                        elif name == 'CACERT':
+                            self.rc_cacert = value
             else:
                 print 'Error: rc file does not exist %s' % (openrc_file)
                 success = False
@@ -95,6 +100,7 @@ class Credentials(object):
                 self.rc_username = os.environ['OS_USERNAME']
                 self.rc_auth_url = os.environ['OS_AUTH_URL']
                 self.rc_tenant_name = os.environ['OS_TENANT_NAME']
+                self.rc_cacert = os.environ['OS_CACERT']
 
         # always override with CLI argument if provided
         if pwd:


### PR DESCRIPTION
Often OpenStack installations have their own Root CA and certificate chain. With this patch one can specify the certificate chain bundle using environment variables or an openrc file
