### PR TITLE
Use PYTHONPATH as base path for finding plugins.

### DIFF
--- a/ha_engine/ha_parser.py
+++ b/ha_engine/ha_parser.py
@@ -129,7 +129,7 @@ class HAParser(object):
         Return _resource_dirs if all the paths are valid otherwise returns
         error and exit.
         """
-        ha_infra_dir = os.environ.get('HAPATH', None)
+        ha_infra_dir = os.environ.get('PYTHONPATH', None)
         self.resource_dirs.append(ha_infra_dir)
 
     def map_plugins_to_class_and_create_instances(self):

--- a/install.sh
+++ b/install.sh
@@ -2,11 +2,12 @@
 echo "Cloud99 Setup"
 echo "-------------"; echo
 
+cur_script=$(readlink -f "${BASH_SOURCE[0]}")
+script_dir=$(dirname "${cur_script}")
+
 #setup_logs="/tmp/setup.log_"`date +"%b%d%y_%H%M%S"`
-curdir=`pwd`
-cur_root=${curdir%/*}
 old_pythonpath=${PYTHONPATH}
-pythonpath="${curdir}"
+pythonpath="${script_dir}"
 
 
 #echo "setup log: $setup_logs"; echo
@@ -15,11 +16,11 @@ pythonpath="${curdir}"
 ################################################
 # Set the pythonpath.
 ################################################
-export HAPATH=${pythonpath}
+export HAPATH=${PWD}
 export PYTHONPATH=${pythonpath}
 
 echo "================================================="
 echo "New PYTHONPATH: '${PYTHONPATH}'"
-echo "New HAPATH: '${PYTHONPATH}'"
+echo "New HAPATH: '${HAPATH}'"
 echo "Old PYTHONPATH: '${old_pythonpath}'"
 echo "================================================="


### PR DESCRIPTION
Originally HAPATH env variable is used both for finding monitor/runner/disruptor
plugins and configurations. Using PYTHONPATH for plugins is sensible
(since plugins are written in python) and it separates the
responsibility of configuration (which now can be moved outside the
source tree).

Usage:

Let's say we have the following setup:
```
`- my-env
   `- Cloud99 [git cloned]
      `- install.sh
      `- ...
   `- configs
      `- runners.yaml
      `- monitors.yaml
      `- disruptors.yaml
      `- executor.yaml
      `- ...`
```

Using the following commands will set up correctly the paths:

cd my-env
. Cloud99/install.sh