### PR TITLE
Add timestamp to terminal logging.

### DIFF
--- a/ha_engine/ha_infra.py
+++ b/ha_engine/ha_infra.py
@@ -11,6 +11,7 @@ import ha_parser
 import os
 import utils.utils as utils
 from ha_constants import HAConstants
+import datetime
 
 LOG_NAME = 'HA_AUTOMATION_INFRA'
 DEBUG = False
@@ -401,7 +402,7 @@ def display_on_terminal(self, *kwargs):
         if color is not None:
             data = stringc(data, color)
 
-        output = get_plugin_name(self) + " :: " + data
+        output = get_plugin_name(self) + "(" + datetime.datetime.now().strftime("%H:%M:%S") + ") ::" + data
         p.write(output)
 
 


### PR DESCRIPTION
It makes sense to have timestamps in front of all terminal logs so that one knows when an actual failure happened - it helps to correlate with log server data, etc.